### PR TITLE
Remove ocveralls from the OPAM file

### DIFF
--- a/opam
+++ b/opam
@@ -25,6 +25,5 @@ depends: [
   "ssl"
   "oasis"
   "async"
-  "ocveralls" {test}
   "bisect"
 ]


### PR DESCRIPTION
It's not needed for the build, and is explicitly installed by the
coverage script.