### PR TITLE
test: workaround new checks in async

### DIFF
--- a/async/protocol_async.ml
+++ b/async/protocol_async.ml
@@ -33,6 +33,7 @@ module M = struct
     include Cohttp_async_io
 
     let map f t = Deferred.map ~f t
+    let iter f t = Deferred.List.iter t ~f
     let any = Deferred.any
     let is_determined = Deferred.is_determined
   end

--- a/core/s.mli
+++ b/core/s.mli
@@ -27,6 +27,8 @@ module type BACKEND = sig
 
     val map: ('a -> 'b) -> 'a t -> 'b t
 
+    val iter: ('a -> unit t) -> 'a list -> unit t
+
     val any: 'a t list -> 'a t
 
     val is_determined: 'a t -> bool

--- a/core_test/client_async_main.ml
+++ b/core_test/client_async_main.ml
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+module P = Printf
+
 open Core.Std
 open Async.Std
 
@@ -57,7 +59,7 @@ let main () =
       loop ()
   ) >>= fun () ->
   let time = Time.diff (Time.now()) start in
-  Printf.printf "Finished %d RPCs in %.02f\n%!" !counter (Time.Span.to_sec time);
+  P.printf "Finished %d RPCs in %.02f\n%!" !counter (Time.Span.to_sec time);
   Client.rpc ~t ~queue:!name ~body:shutdown () >>|= fun _ ->
   Shutdown.exit 0
 
@@ -67,7 +69,7 @@ let _ =
     "-name", Arg.Set_string name, (Printf.sprintf "name to send message to (default %s)" !name);
     "-payload", Arg.Set_string payload, (Printf.sprintf "payload of message to send (default %s)" !payload);
     "-secs", Arg.String (fun x -> timeout := Some (Float.of_string x)), (Printf.sprintf "number of seconds to repeat the same message for (default %s)" (match !timeout with None -> "None" | Some x -> Float.to_string x));
-  ] (fun x -> Printf.fprintf stderr "Ignoring unexpected argument: %s" x)
+  ] (fun x -> P.fprintf stderr "Ignoring unexpected argument: %s" x)
     "Send a message to a name, optionally waiting for a response";
   let (_: 'a Deferred.t) = main () in
   never_returns (Scheduler.go ())

--- a/core_test/server_async_main.ml
+++ b/core_test/server_async_main.ml
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+module P = Printf
+
 open Core.Std
 open Async.Std
 
@@ -42,7 +44,7 @@ let _ =
   Arg.parse [
     "-path", Arg.Set_string path, (Printf.sprintf "path broker listens on (default %s)" !path);
     "-name", Arg.Set_string name, (Printf.sprintf "name to send message to (default %s)" !name);
-  ] (fun x -> Printf.fprintf stderr "Ignoring unexpected argument: %s" x)
+  ] (fun x -> P.fprintf stderr "Ignoring unexpected argument: %s" x)
     "Respond to RPCs on a name";
 
   let (_: 'a Deferred.t) = main () in

--- a/lwt/protocol_lwt.ml
+++ b/lwt/protocol_lwt.ml
@@ -29,6 +29,7 @@ module M = struct
     include Cohttp_lwt_unix_io
 
     let map = Lwt.map
+    let iter = Lwt_list.iter_s
     let any = Lwt.choose
     let is_determined t = Lwt.state t <> Lwt.Sleep
   end


### PR DESCRIPTION
The test cases are being naughty and performing regular blocking
I/O in an async program. New async now checks for this and the program
fails to compile. This patch works around this check, since it's not
critical for our test code and should unblock travis.

Signed-off-by: David Scott <dave.scott@unikernel.com>