### PR TITLE
Coveralls update

### DIFF
--- a/.coveralls.sh
+++ b/.coveralls.sh
@@ -1,8 +1,43 @@
 #!/bin/sh
+set -e
+# Make sure we're not echoing any sensitive data
+set +x
+
+COVERAGE_DIR=.coverage
+rm -rf $COVERAGE_DIR
+mkdir -p $COVERAGE_DIR
+pushd $COVERAGE_DIR
+if [ -z "$KEEP" ]; then trap "popd; rm -rf $COVERAGE_DIR" EXIT; fi
+
+$(which cp) -r ../* .
 
 eval `opam config env`
-opam install ocveralls -y
+opam pin add -n bisect_ppx git://github.com/rleonid/bisect_ppx#0.2.2
+opam install -y bisect_ppx oasis ocveralls
+
+sed -i '/BuildDepends:/ s/$/, bisect_ppx/' _oasis
+if [ -f ../.coverage.excludes ]; then
+  ln -s ../.coverage.excludes
+  sed -i '/ByteOpt:/ s/$/ -ppxopt bisect_ppx,"-exclude-file ..\/.coverage.excludes"/' _oasis
+  sed -i '/NativeOpt:/ s/$/ -ppxopt bisect_ppx,"-exclude-file ..\/.coverage.excludes"/' _oasis
+fi
+oasis setup
+
+./configure
 make
-BISECT_FILE=_build/coverage ./basic-rpc-test.sh
-# This needs debugging:
-#`opam config var bin`/ocveralls --prefix _build _build/coverage*.out --send
+
+find . -name bisect* | xargs rm -f
+./basic-rpc-test.sh -runner sequential
+
+bisect-report bisect*.out -I _build -text report
+bisect-report bisect*.out -I _build -summary-only -text summary
+(cd _build; bisect-report ../bisect*.out -html ../report-html)
+
+if [ -n "$TRAVIS" ]; then
+  echo "\$TRAVIS set; running ocveralls and sending to coveralls.io..."
+  ocveralls --prefix _build bisect*.out --send
+else
+  echo "\$TRAVIS not set; displaying results of bisect-report..."
+  cat report
+  cat summary
+fi

--- a/_oasis
+++ b/_oasis
@@ -23,7 +23,7 @@ Library message_switch
   Path:               core
   Findlibname:        message_switch
   Modules:            Protocol, Make, Monad, Result, S
-  BuildDepends:       cohttp (>= 0.15.0) ,rpclib,rpclib.json,rpclib.syntax,sexplib,sexplib.syntax,re.str, bisect
+  BuildDepends:       cohttp (>= 0.15.0) ,rpclib,rpclib.json,rpclib.syntax,sexplib,sexplib.syntax,re.str
 
 Library message_switch_lwt
   Build$:             flag(lwt)
@@ -34,7 +34,7 @@ Library message_switch_lwt
   Findlibparent:      message_switch
   Findlibname:        lwt
   Modules:            Protocol_lwt
-  BuildDepends:       lwt,lwt.unix,cohttp (>= 0.15.0),cohttp.lwt,rpclib,rpclib.json,rpclib.syntax,message_switch, bisect
+  BuildDepends:       lwt,lwt.unix,cohttp (>= 0.15.0),cohttp.lwt,rpclib,rpclib.json,rpclib.syntax,message_switch
 
 Library message_switch_async
   Build$:             flag(async)
@@ -45,7 +45,7 @@ Library message_switch_async
   Findlibparent:      message_switch
   Findlibname:        async
   Modules:            Protocol_async
-  BuildDepends:       threads,async,cohttp (>= 0.15.0),cohttp.async,rpclib,rpclib.json,rpclib.syntax,message_switch, bisect
+  BuildDepends:       threads,async,cohttp (>= 0.15.0),cohttp.async,rpclib,rpclib.json,rpclib.syntax,message_switch
 
 Library message_switch_unix
   CompiledObject:     best
@@ -55,7 +55,7 @@ Library message_switch_unix
   Findlibparent:      message_switch
   Findlibname:        unix
   Modules:            Protocol_unix, Protocol_unix_scheduler
-  BuildDepends:       unix,threads,cohttp (>= 0.15.0),rpclib,rpclib.json,rpclib.syntax,message_switch, bisect
+  BuildDepends:       unix,threads,cohttp (>= 0.15.0),rpclib,rpclib.json,rpclib.syntax,message_switch
 
 Library message_switch_server
   Build$:             flag(lwt)
@@ -68,7 +68,7 @@ Library message_switch_server
   Findlibparent:      message_switch
   Findlibname:        server
   Modules:            Clock, Relation, Q, Logging, Switch
-  BuildDepends:       lwt,lwt.syntax,sexplib,sexplib.syntax,mtime,mtime.os,cohttp (>= 0.15.0),cohttp.lwt,rpclib,rpclib.json,rpclib.syntax,message_switch,mirage-block-unix,shared-block-ring,cmdliner,io-page.unix, bisect
+  BuildDepends:       lwt,lwt.syntax,sexplib,sexplib.syntax,mtime,mtime.os,cohttp (>= 0.15.0),cohttp.lwt,rpclib,rpclib.json,rpclib.syntax,message_switch,mirage-block-unix,shared-block-ring,cmdliner,io-page.unix
 
 Executable m_cli
   CompiledObject:     best
@@ -78,7 +78,7 @@ Executable m_cli
   MainIs:             main.ml
   Custom:             true
   Install:            false
-  BuildDepends:       message_switch, message_switch.unix, cmdliner, bisect
+  BuildDepends:       message_switch, message_switch.unix, cmdliner
 
 Executable link_test
   Build$:             flag(lwt)&&flag(tests)
@@ -89,7 +89,7 @@ Executable link_test
   MainIs:             link_test_main.ml
   Custom:             true
   Install:            false
-  BuildDepends:       message_switch, message_switch.lwt, lwt, lwt.unix, lwt.syntax, cohttp, cohttp.lwt, bisect
+  BuildDepends:       message_switch, message_switch.lwt, lwt, lwt.unix, lwt.syntax, cohttp, cohttp.lwt
 
 Executable client
   Build$:             flag(lwt)&&flag(tests)
@@ -100,7 +100,7 @@ Executable client
   MainIs:             client_main.ml
   Custom:             true
   Install:            false
-  BuildDepends:       message_switch, message_switch.lwt, lwt, lwt.unix, lwt.syntax, cohttp, cohttp.lwt, bisect
+  BuildDepends:       message_switch, message_switch.lwt, lwt, lwt.unix, lwt.syntax, cohttp, cohttp.lwt
 
 Executable client_async
   Build$:             flag(async)&&flag(tests)
@@ -111,7 +111,7 @@ Executable client_async
   MainIs:             client_async_main.ml
   Custom:             true
   Install:            false
-  BuildDepends:       message_switch, message_switch.async, async, async_unix, threads, cohttp, cohttp.async, bisect
+  BuildDepends:       message_switch, message_switch.async, async, async_unix, threads, cohttp, cohttp.async
 
 Executable client_unix
   CompiledObject:     best
@@ -122,7 +122,7 @@ Executable client_unix
   Build$:             flag(tests)
   Custom:             true
   Install:            false
-  BuildDepends:       message_switch, message_switch.unix, cohttp, bisect
+  BuildDepends:       message_switch, message_switch.unix, cohttp
 
 Executable server
   Build$:             flag(lwt)&&flag(tests)
@@ -133,7 +133,7 @@ Executable server
   MainIs:             server_main.ml
   Custom:             true
   Install:            false
-  BuildDepends:       message_switch, message_switch.lwt, lwt, lwt.unix, lwt.syntax, cohttp, cohttp.lwt, cmdliner, bisect
+  BuildDepends:       message_switch, message_switch.lwt, lwt, lwt.unix, lwt.syntax, cohttp, cohttp.lwt, cmdliner
 
 Executable server_async
   Build$:             flag(async)&&flag(tests)
@@ -144,7 +144,7 @@ Executable server_async
   MainIs:             server_async_main.ml
   Custom:             true
   Install:            false
-  BuildDepends:       message_switch, message_switch.async, async, async_unix, threads, cohttp, cohttp.async, bisect
+  BuildDepends:       message_switch, message_switch.async, async, async_unix, threads, cohttp, cohttp.async
 
 Executable server_unix
   CompiledObject:     best
@@ -155,7 +155,7 @@ Executable server_unix
   Build$:             flag(tests)
   Custom:             true
   Install:            false
-  BuildDepends:       message_switch, message_switch.unix, bisect
+  BuildDepends:       message_switch, message_switch.unix
 
 Executable switch
   Build$:             flag(lwt)
@@ -166,4 +166,4 @@ Executable switch
   MainIs:             switch_main.ml
   Custom:             true
   Install:            false
-  BuildDepends:       message_switch, message_switch.lwt, message_switch.server, lwt, lwt.unix, lwt.syntax, cohttp, cohttp.lwt, bisect
+  BuildDepends:       message_switch, message_switch.lwt, message_switch.server, lwt, lwt.unix, lwt.syntax, cohttp, cohttp.lwt

--- a/opam
+++ b/opam
@@ -25,5 +25,4 @@ depends: [
   "ssl"
   "oasis"
   "async"
-  "bisect"
 ]


### PR DESCRIPTION
This PR flips bisect off by default, and only adds it in when running the `.coveralls.sh` script. Before this PR, an `opam pin` of this repository would cause bisect to be linked into the library. When trying to bisect other projects that use this library, the bisect tool would fail as the source to this `message-switch` repository isn't available.