### PR TITLE
Merge ppx_trunk into master for moving to OCaml 4.02.3 and PPX

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -23,7 +23,7 @@ Library message_switch
   Path:               core
   Findlibname:        message_switch
   Modules:            Protocol, Make, Monad, Mresult, S
-  BuildDepends:       cohttp (>= 0.15.0) ,rpclib,rpclib.json,rpclib.syntax,sexplib,sexplib.syntax,re.str
+  BuildDepends:       cohttp (>= 0.15.0),rpclib,rpclib.json,ppx_deriving_rpc,sexplib,ppx_sexp_conv,re.str
 
 Library message_switch_lwt
   Build$:             flag(lwt)
@@ -34,7 +34,7 @@ Library message_switch_lwt
   Findlibparent:      message_switch
   Findlibname:        lwt
   Modules:            Protocol_lwt
-  BuildDepends:       lwt,lwt.unix,cohttp (>= 0.15.0),cohttp.lwt,rpclib,rpclib.json,message_switch
+  BuildDepends:       lwt,lwt.unix,cohttp (>= 0.15.0),cohttp.lwt,rpclib,rpclib.json,ppx_deriving_rpc,message_switch
 
 Library message_switch_async
   Build$:             flag(async)
@@ -45,7 +45,7 @@ Library message_switch_async
   Findlibparent:      message_switch
   Findlibname:        async
   Modules:            Protocol_async
-  BuildDepends:       threads,async,cohttp (>= 0.15.0),cohttp.async,rpclib,rpclib.json,message_switch
+  BuildDepends:       threads,async,cohttp (>= 0.15.0),cohttp.async,rpclib,rpclib.json,ppx_deriving_rpc,message_switch
 
 Library message_switch_unix
   CompiledObject:     best
@@ -55,7 +55,7 @@ Library message_switch_unix
   Findlibparent:      message_switch
   Findlibname:        unix
   Modules:            Protocol_unix, Protocol_unix_scheduler
-  BuildDepends:       unix,threads,cohttp (>= 0.15.0),rpclib,rpclib.json,rpclib.syntax,message_switch
+  BuildDepends:       unix,threads,cohttp (>= 0.15.0),rpclib,rpclib.json,ppx_deriving_rpc,message_switch
 
 Library message_switch_server
   Build$:             flag(lwt)
@@ -68,7 +68,7 @@ Library message_switch_server
   Findlibparent:      message_switch
   Findlibname:        server
   Modules:            Clock, Relation, Q, Logging, Mswitch
-  BuildDepends:       lwt,sexplib,sexplib.syntax,mtime,mtime.os,cohttp (>= 0.15.0),cohttp.lwt,rpclib,rpclib.json,message_switch,mirage-block-unix,shared-block-ring,cmdliner,io-page.unix
+  BuildDepends:       lwt,sexplib,ppx_sexp_conv,mtime,mtime.os,cohttp (>= 0.15.0),cohttp.lwt,rpclib,rpclib.json,ppx_deriving_rpc,message_switch,mirage-block-unix,shared-block-ring,cmdliner,io-page.unix
 
 Executable m_cli
   CompiledObject:     best

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -35,7 +35,7 @@ module Common = struct
     verbose: bool;
     debug: bool;
     path: string;
-  } with rpc
+  } [@@deriving rpc]
 
   let make verbose debug path =
     { verbose; debug; path }

--- a/core/protocol.ml
+++ b/core/protocol.ml
@@ -17,10 +17,10 @@ open Sexplib.Std
 
 exception Queue_deleted of string
 
-type message_id = (string * int64) with rpc, sexp
+type message_id = (string * int64) [@@deriving rpc, sexp]
 (** uniquely identifier for this message *)
 
-type message_id_opt = message_id option with rpc, sexp
+type message_id_opt = message_id option [@@deriving rpc, sexp]
 
 let timeout = 30.
 
@@ -28,11 +28,11 @@ module Message = struct
   type kind =
     | Request of string
     | Response of message_id
-  with rpc, sexp
+  [@@deriving rpc, sexp]
   type t = {
     payload: string; (* switch to Rpc.t *)
     kind: kind;
-  } with rpc, sexp
+  } [@@deriving rpc, sexp]
 
 end
 
@@ -40,7 +40,7 @@ module Event = struct
   type message =
     | Message of message_id * Message.t
     | Ack of message_id
-  with rpc
+  [@@deriving rpc]
 
   type t = {
     time: float;
@@ -49,7 +49,7 @@ module Event = struct
     output: string option;
     message: message;
     processing_time: int64 option;
-  } with rpc
+  } [@@deriving rpc]
 
 end
 
@@ -58,7 +58,7 @@ module In = struct
     from: string option;
     timeout: float;
     queues: string list;
-  } with rpc
+  } [@@deriving rpc]
 
   type t =
     | Login of string            (** Associate this transport-level channel with a session *)
@@ -74,7 +74,7 @@ module In = struct
     | Diagnostics                (** return a diagnostic dump *)
     | Shutdown                   (** shutdown the switch *)
     | Get of string list         (** return a web interface resource *)
-  with rpc
+  [@@deriving rpc]
 
   let slash = Re_str.regexp_string "/"
   let split = Re_str.split_delim slash
@@ -147,7 +147,7 @@ end
 type origin =
   | Anonymous of string (** An un-named connection, probably a temporary client connection *)
   | Name of string   (** A service with a well-known name *)
-with rpc, sexp
+[@@deriving sexp, rpc]
 (** identifies where a message came from *)
 
 module Entry = struct
@@ -155,7 +155,7 @@ module Entry = struct
     origin: origin;
     time: int64;
     message: Message.t;
-  } with rpc, sexp
+  } [@@deriving rpc, sexp]
   (** an enqueued message *)
 
   let make time origin message =
@@ -163,12 +163,12 @@ module Entry = struct
 end
 
 module Diagnostics = struct
-  type queue_contents = (message_id * Entry.t) list with rpc
+  type queue_contents = (message_id * Entry.t) list [@@deriving rpc]
 
   type queue = {
     next_transfer_expected: int64 option;
     queue_contents: queue_contents;
-  } with rpc
+  } [@@deriving rpc]
 
   type t = {
     start_time: int64;
@@ -176,20 +176,20 @@ module Diagnostics = struct
     permanent_queues: (string * queue) list;
     transient_queues: (string * queue) list;
   }
-  with rpc
+  [@@deriving rpc]
 end
 
 module Out = struct
   type transfer = {
     messages: (message_id * Message.t) list;
     next: string;
-  } with rpc
+  } [@@deriving rpc]
 
   type trace = {
     events: (int64 * Event.t) list;
-  } with rpc
+  } [@@deriving rpc]
 
-  type queue_list = string list with rpc
+  type queue_list = string list [@@deriving rpc]
   let rpc_of_string_list = rpc_of_queue_list
   let string_list_of_rpc = queue_list_of_rpc
 

--- a/core/protocol.mli
+++ b/core/protocol.mli
@@ -16,7 +16,7 @@
 
 exception Queue_deleted of string
 
-type message_id = string * int64 with sexp
+type message_id = string * int64 [@@deriving sexp]
 (** uniquely identifier for this message *)
 
 val rpc_of_message_id: message_id -> Rpc.t
@@ -31,12 +31,12 @@ module Message : sig
   type kind =
     | Request of string
     | Response of message_id
-  with sexp
+  [@@deriving sexp]
   type t = {
     payload: string; (* switch to Rpc.t *)
     kind: kind;
   }
-  with sexp
+  [@@deriving sexp]
   val t_of_rpc: Rpc.t -> t
   val rpc_of_t: t -> Rpc.t
 end
@@ -95,7 +95,7 @@ end
 type origin =
   | Anonymous of string (** An un-named connection, probably a temporary client connection *)
   | Name of string   (** A service with a well-known name *)
-with sexp
+[@@deriving sexp]
 (** identifies where a message came from *)
 
 module Entry : sig
@@ -103,7 +103,7 @@ module Entry : sig
     origin: origin;
     time: int64; (** ns *)
     message: Message.t;
-  } with sexp
+  } [@@deriving sexp]
   (** an enqueued message *)
 
   val make: int64 -> origin -> Message.t -> t

--- a/opam
+++ b/opam
@@ -13,13 +13,13 @@ depends: [
   "cohttp" {>= "0.15.0" }
   "rpc"
   "sexplib"
+  "ppx_sexp_conv"
   "ounit"
   "syslog"
   "uri"
   "re"
-  "rpc"
   "mtime"
-  "mirage-block-unix"
+  "mirage-block-unix" {>= "2.4.0"}
   "shared-block-ring"
   "cmdliner"
   "ssl"

--- a/switch/logging.ml
+++ b/switch/logging.ml
@@ -98,8 +98,8 @@ type traced_operation = [
     `Suspend_ack ] * [ `Int64 of int64 | `Bool of bool ]
   | `Get of string * string * [ `Producer | `Consumer | `Suspend |
     `Suspend_ack ] * [ `Int64 of int64 | `Bool of bool ]
-] with sexp
-type traced_operation_list = traced_operation list with sexp
+] [@@deriving sexp]
+type traced_operation_list = traced_operation list [@@deriving sexp]
 let trace _ = Lwt.return ()
 
 let rec logging_thread () =

--- a/switch/logging.mli
+++ b/switch/logging.mli
@@ -30,8 +30,8 @@ type traced_operation = [
     `Suspend_ack ] * [ `Int64 of int64 | `Bool of bool ]
   | `Get of string * string * [ `Producer | `Consumer | `Suspend |
     `Suspend_ack ] * [ `Int64 of int64 | `Bool of bool ]
-] with sexp
-type traced_operation_list = traced_operation list with sexp
+] [@@deriving sexp]
+type traced_operation_list = traced_operation list [@@deriving sexp]
 val trace: traced_operation_list -> unit Lwt.t
 
 val logging_thread: unit -> unit Lwt.t

--- a/switch/q.ml
+++ b/switch/q.ml
@@ -21,7 +21,7 @@ open Clock
 module Int64Map = struct
   include Map.Make(Int64)
 
-  type 'a t' = (int64 * 'a) list with sexp
+  type 'a t' = (int64 * 'a) list [@@deriving sexp]
   let t_of_sexp a sexp =
     let t' = t'_of_sexp a sexp in
     List.fold_left (fun acc (x, y) -> add x y acc) empty t'
@@ -30,7 +30,7 @@ end
 
 module Lwt_condition = struct
   include Lwt_condition
-  type t' = string with sexp
+  type t' = string [@@deriving sexp]
 
   let t_of_sexp _ _ = Lwt_condition.create ()
   let sexp_of_t _ _ = sexp_of_t' "Lwt_condition.t"
@@ -38,7 +38,7 @@ end
 
 module Lwt_mutex = struct
   include Lwt_mutex
-  type t' = string with sexp
+  type t' = string [@@deriving sexp]
 
   let t_of_sexp _ = Lwt_mutex.create ()
   let sexp_of_t _ = sexp_of_t' "Lwt_mutex.t"
@@ -46,7 +46,7 @@ end
 
 type waiter = {
   mutable next_id: int64;
-} with sexp
+} [@@deriving sexp]
 
 type t = {
   q: Protocol.Entry.t Int64Map.t;
@@ -54,7 +54,7 @@ type t = {
   length: int;
   owner: string option; (* if transient, name of the owning connection *)
   waiter: waiter;
-} with sexp
+} [@@deriving sexp]
 
 let t_of_sexp sexp =
   let t = t_of_sexp sexp in
@@ -83,7 +83,7 @@ let make owner name =
 module StringMap = struct
   include Map.Make(String)
 
-  type 'a t' = (string * 'a) list with sexp
+  type 'a t' = (string * 'a) list [@@deriving sexp]
   let t_of_sexp a sexp =
     let t' = t'_of_sexp a sexp in
     List.fold_left (fun acc (x, y) -> add x y acc) empty t'
@@ -93,7 +93,7 @@ end
 module StringSet = struct
   include Set.Make(String)
 
-  type t' = string list with sexp
+  type t' = string list [@@deriving sexp]
   let t_of_sexp sexp =
     let t' = t'_of_sexp sexp in
     List.fold_left (fun acc x -> add x acc) empty t'
@@ -103,7 +103,7 @@ end
 type queues = {
   queues: t StringMap.t;
   by_owner: StringSet.t StringMap.t;
-} with sexp
+} [@@deriving sexp]
 
 let empty = {
   queues = StringMap.empty;
@@ -216,13 +216,13 @@ module Op = struct
   type directory_operation =
     | Add of string option * string
     | Remove of string
-  with sexp
+  [@@deriving sexp]
 
   type t =
     | Directory of directory_operation
     | Ack of Protocol.message_id
     | Send of Protocol.origin * string * int64 * Protocol.Message.t (* origin * queue * id * body *)
-  with sexp
+  [@@deriving sexp]
 
   let of_cstruct x =
     try

--- a/switch/q.mli
+++ b/switch/q.mli
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type t with sexp
+type t [@@deriving sexp]
 (** a persistent message queue with a well-known name.
     XXX these aren't really queues as messages are removed
     from the middle *)
@@ -26,7 +26,7 @@ val get_owner: t -> string option
 (** [get_owner t] returns the owner of [t] where the owner is the entity
     which, when it is destroyed, the queue is also cleaned up. *)
 
-type queues with sexp
+type queues [@@deriving sexp]
 (** A set of message queues *)
 
 val empty: queues

--- a/unix/protocol_unix_scheduler.ml
+++ b/unix/protocol_unix_scheduler.ml
@@ -109,9 +109,9 @@ let m = Mutex.create ()
 
 type time =
   | Absolute of int64
-  | Delta of int with rpc
+  | Delta of int [@@deriving rpc]
 
-type t = int64 * int with rpc
+type t = int64 * int [@@deriving rpc]
 
 let now () = Unix.gettimeofday () |> ceil |> Int64.of_float
 
@@ -119,8 +119,8 @@ module Dump = struct
   type u = {
     time: int64;
     thing: string;
-  } with rpc
-  type t = u list with rpc
+  } [@@deriving rpc]
+  type t = u list [@@deriving rpc]
   let make () =
     let now = now () in
     Mutex.execute m


### PR DESCRIPTION

    1bd9a36 2017-02-28 (HEAD -> ppx_trunk, tag: v1.2.0, tag: v1.0.1.ppx, origin/ppx_trunk) Merge pull request #27 from gaborigloi/ppx_trunk [GitHub]
    09130b7 2017-02-27 switch_main.ml: simplify matches using "function" [Gabor Igloi]
    9c2c271 2016-11-23 Use newer ocaml-rpc [Gabor Igloi]
    a591bbb 2016-11-07 Switch to ppx for sexp and rpc [Gabor Igloi]
Signed-off-by: Christian Lindig <christian.lindig@citrix.com>
