### PR TITLE
CA-248467: message-cli tail --follow causes VM reboot too slow

### DIFF
--- a/switch/switch_main_helper.ml
+++ b/switch/switch_main_helper.ml
@@ -1,0 +1,20 @@
+(*
+ * Copyright (c) Citrix Systems Inc.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+open Lwt
+
+(* Held while processing a non-blocking request *)
+let m = Lwt_mutex.create ()
+

--- a/switch/trace.ml
+++ b/switch/trace.ml
@@ -42,7 +42,7 @@ let get from timeout : (int64 * Protocol.Event.t) list Lwt.t =
   let sleep = Lwt_unix.sleep timeout in
   let rec wait_for_data () =
     if !next_id <= from then
-      Lwt_condition.wait c >>= wait_for_data
+      Lwt_condition.wait ?mutex:(Some Switch_main_helper.m) c >>= wait_for_data
     else return ()
   in
   (* Wait until some data is available ie. when next_id > from (or timeout) *)


### PR DESCRIPTION
Signed-off-by: Deli Zhang <Deli.Zhang@citrix.com>

Hi Sir,
Please help to review this PR, you can get details about the issue from CA-248467 with my analysis.
The issue is little difficult to resolve thoroughly, while from my testing I prefer to this simple change, after all  message-cli is just a tool and it would not be used in general situation.
If you have any better idea please let me know.
Thanks,
Deli