### PR TITLE
CA-256884: do not crash on client ECONNRESET

### DIFF
--- a/opam
+++ b/opam
@@ -15,20 +15,19 @@ remove: [
   ["ocamlfind" "remove" "message_switch"]
 ]
 depends: [
-  "ocamlfind"
-  "cohttp" {>= "0.15.0" }
-  "rpc"
+  "oasis" {build}
+  "ocamlfind" {build}
+  "base-unix"
+  "cohttp" {>= "0.21.1" & < "0.22.0"}
+  "rpc" {>= "1.9.51"}
   "sexplib"
   "ppx_sexp_conv"
-  "ounit"
-  "syslog"
   "uri"
   "re"
-  "mtime"
+  "mtime" {< "1.0.0"}
   "mirage-block-unix" {>= "2.4.0"}
-  "shared-block-ring"
+  "shared-block-ring" {>= "2.3.0"}
   "cmdliner"
-  "ssl"
-  "oasis"
-  "async"
+  "async" {< "v0.9.0"}
 ]
+

--- a/switch/switch_main.ml
+++ b/switch/switch_main.ml
@@ -295,7 +295,14 @@ let make_server config =
      | Unix.Unix_error(Unix.ENOENT, _, _) -> return ()
      | e -> fail e)
   >>= fun () ->
-  Cohttp_lwt_unix.Server.create ~mode:(`Unix_domain_socket (`File config.path)) t
+  (* see ocaml-cohttp/issues/511 for additional context *)
+  let on_exn = function
+    | Unix.Unix_error (error, func, arg) ->
+      let msg = Printf.sprintf "Client connection error %s: %s(%S)" (Unix.error_message error) func arg in
+      Lwt_log.ign_warning msg
+    | exn -> Lwt_log.ign_error ~exn "Unhandled exception" 
+  in
+  Cohttp_lwt_unix.Server.create ~on_exn ~mode:(`Unix_domain_socket (`File config.path)) t
 
 exception Not_a_directory of string
 exception Does_not_exist of string

--- a/switch/switch_main.ml
+++ b/switch/switch_main.ml
@@ -297,6 +297,9 @@ let make_server config =
   >>= fun () ->
   (* see ocaml-cohttp/issues/511 for additional context *)
   let on_exn = function
+    | Unix.Unix_error (Unix.EPIPE, _, _) ->
+        (* This is the common client disconnection error - no need to log it*)
+        ()
     | Unix.Unix_error (error, func, arg) ->
       let msg = Printf.sprintf "Client connection error %s: %s(%S)" (Unix.error_message error) func arg in
       Lwt_log.ign_warning msg


### PR DESCRIPTION
This depends on https://github.com/xapi-project/xs-opam/pull/111

A new `~on_err` handler allows custom management of
client connection errors, this can be used to improve
logging and solve a regression that was causing
`message-switch` to crash on sudder restart of connected
daemons.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>