### PR TITLE
Use newer mtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
 sudo: required
 env:
   global:
-    - OCAML_VERSION=4.02
+    - OCAML_VERSION=4.04
     - PACKAGE=message-switch
   matrix:
     - BASE_REMOTE=git://github.com/xapi-project/xs-opam XS_COV=1 COV_CONF="./configure"

--- a/_oasis
+++ b/_oasis
@@ -68,7 +68,7 @@ Library message_switch_server
   Findlibparent:      message_switch
   Findlibname:        server
   Modules:            Clock, Relation, Q, Logging, Mswitch
-  BuildDepends:       lwt,sexplib,ppx_sexp_conv,mtime,mtime.os,cohttp (>= 0.15.0),cohttp.lwt,rpclib,rpclib.json,ppx_deriving_rpc,message_switch,mirage-block-unix,shared-block-ring,cmdliner,io-page.unix
+  BuildDepends:       lwt,sexplib,ppx_sexp_conv,mtime,mtime.clock.os,cohttp (>= 0.15.0),cohttp.lwt,rpclib,rpclib.json,ppx_deriving_rpc,message_switch,mirage-block-unix,shared-block-ring,cmdliner,io-page.unix
 
 Executable m_cli
   CompiledObject:     best

--- a/opam
+++ b/opam
@@ -25,7 +25,7 @@ depends: [
   "ppx_sexp_conv"
   "uri"
   "re"
-  "mtime" {>= "1.0.0"}
+  "mtime" {>= "1.0.0" & < "2.0.0"}
   "mirage-block-unix" {>= "2.4.0"}
   "shared-block-ring" {>= "2.3.0"}
   "cmdliner"

--- a/opam
+++ b/opam
@@ -25,7 +25,7 @@ depends: [
   "ppx_sexp_conv"
   "uri"
   "re"
-  "mtime" {< "1.0.0"}
+  "mtime" {>= "1.0.0"}
   "mirage-block-unix" {>= "2.4.0"}
   "shared-block-ring" {>= "2.3.0"}
   "cmdliner"


### PR DESCRIPTION
I wanted to use mtime 1.X in a PR, but could not, because message-switch was not compatible with it. If this PR is merged, mtime in xs-opam will also need to be updated.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>