### PR TITLE
message-switch, message-switch-unix: port to safe-strings without changing the interface

### DIFF
--- a/.coverage.sh
+++ b/.coverage.sh
@@ -10,7 +10,7 @@ if [ -z "$KEEP" ]; then trap "popd; rm -rf $COVERAGE_DIR" EXIT; fi
 
 $(which cp) -r ../* .
 
-opam pin add bisect_ppx 1.3.0 -y
+opam pin add bisect_ppx 1.3.3 -y
 opam install ocveralls -y
 
 # install test deps

--- a/unix/protocol_unix.ml
+++ b/unix/protocol_unix.ml
@@ -65,11 +65,11 @@ module IO = struct
       | false -> return None
 
     let read ic n =
-      let buf = String.make n '\000' in
+      let buf = Bytes.make n '\000' in
       let actually_read = input ic buf 0 n in
       if actually_read = n
-      then buf
-      else String.sub buf 0 actually_read
+      then Bytes.unsafe_to_string buf
+      else Bytes.sub_string buf 0 actually_read
 
     let write oc x =
       output_string oc x; flush oc

--- a/unix/protocol_unix_scheduler.ml
+++ b/unix/protocol_unix_scheduler.ml
@@ -29,7 +29,6 @@ module Mutex = struct
     lock m;
     finally' f (fun () -> unlock m)
 end
-let ( |> ) a b = b a
 
 module Int64Map = Map.Make(struct type t = int64 let compare = compare end)
 
@@ -92,7 +91,7 @@ module Delay = struct
     Mutex.execute x.m
       (fun () ->
          match x.pipe_in with
-         | Some fd -> ignore(Unix.write fd "X" 0 1)
+         | Some fd -> ignore(Unix.write fd (Bytes.of_string "X") 0 1)
          | None -> x.signalled <- true 	 (* If the wait hasn't happened yet then store up the signal *)
       )
 end


### PR DESCRIPTION
In the few places where we use unsafe coercions, you can easily track the ownership of the bytes. They are always contained around the block that deals with them