### PR TITLE
message-switch-core.opam: we use rpclib not the old rpc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: c
-install:
-  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
-script:
-    - bash -ex .travis-opam.sh
 sudo: required
+service: docker
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+script: bash -ex .travis-docker.sh
 env:
   global:
-    - OCAML_VERSION=4.06
     - PACKAGE=message-switch
     - PINS="message-switch-async:. message-switch-cli:. message-switch-core:.  message-switch:.  message-switch-lwt:.  message-switch-unix:."
-  matrix:
     - BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
-matrix:
-    fast_finish: true
-
+  matrix:
+    - DISTRO="debian-9-ocaml-4.06"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     - PACKAGE=message-switch
     - PINS="message-switch-async:. message-switch-cli:. message-switch-core:.  message-switch:.  message-switch-lwt:.  message-switch-unix:."
   matrix:
-    - EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
+    - BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
 matrix:
     fast_finish: true
 

--- a/message-switch-core.opam
+++ b/message-switch-core.opam
@@ -16,9 +16,11 @@ depends: [
   "astring"
   "base-unix"
   "cohttp" {>= "0.21.1"}
-  "rpc" {>= "1.9.51"}
-  "sexplib"
+  "ocaml-migrate-parsetree"
+  "ppx_deriving_rpc"
   "ppx_sexp_conv"
+  "rpclib"
+  "sexplib"
   "mtime" {>= "1.0.0" & < "2.0.0"}
   "mirage-block-unix" {>= "2.4.0"}
   "shared-block-ring" {>= "2.3.0"}


### PR DESCRIPTION
rpc depends on both async and lwt, rpclib allows us to bring in just the one we need