### PR TITLE
CA-322044: Fix file descriptor leak on reconnect

### DIFF
--- a/core/make.ml
+++ b/core/make.ml
@@ -131,7 +131,7 @@ module Client = functor(M: S.BACKEND) -> struct
 
   let connect ~switch:port () =
     let token = M.whoami () in
-    let wrap_connect path f =
+    let protect_connect path f =
       M.connect path >>= fun conn ->
       f conn >>= function
       | `Ok _ as ok -> return ok
@@ -140,9 +140,9 @@ module Client = functor(M: S.BACKEND) -> struct
         return err
     in
     let reconnect () =
-      wrap_connect port @@ fun requests_conn ->
+      protect_connect port @@ fun requests_conn ->
       Connection.rpc requests_conn (In.Login token) >>|= fun (_: string) ->
-      wrap_connect port @@ fun events_conn ->
+      protect_connect port @@ fun events_conn ->
       Connection.rpc events_conn (In.Login token) >>|= fun (_: string) ->
       return (`Ok (requests_conn, events_conn)) in
 


### PR DESCRIPTION
 reconnect () needs to close the old connections if any.
 We also need to handle the case where the 1st IO.connect succeeds, but the 2nd one fails.

The monadic version lacks exception handling, and in both versions it appears that if there are any exceptions raised during the recursive `loop` then that thread would just exit, and further events wouldn't be handled.
That should be addressed under a different ticket though.