### PR TITLE
CA-323813: do not loop indefinetely if message-switch dies

### DIFF
--- a/core/make.ml
+++ b/core/make.ml
@@ -77,6 +77,7 @@ module Client = functor(M: S.BACKEND) -> struct
     | `Unsuccessful_response
     | `Timeout
     | `Queue_deleted of string
+    | `Communication of exn
   ]
 
   type 'a result = ('a, [ `Message_switch of error]) Mresult.result
@@ -91,6 +92,8 @@ module Client = functor(M: S.BACKEND) -> struct
       Format.pp_print_string fmt "Timeout"
     | `Message_switch (`Queue_deleted name) ->
       Format.fprintf fmt "The queue %s has been deleted" name
+    | `Message_switch (`Communication e) ->
+      Format.fprintf fmt "There was a communication failure with message-switch: %s" (Printexc.to_string e)
 
   let error_to_msg = function
     | `Ok x -> `Ok x
@@ -291,6 +294,7 @@ module Server = functor(M: S.BACKEND) -> struct
   type error = [
     | `Failed_to_read_response
     | `Unsuccessful_response
+    | `Communication of exn
   ]
 
   type 'a result = ('a, [ `Message_switch of error]) Mresult.result
@@ -301,6 +305,8 @@ module Server = functor(M: S.BACKEND) -> struct
       Format.pp_print_string fmt "Failed to read response from the message-switch"
     | `Message_switch `Unsuccessful_response ->
       Format.pp_print_string fmt "Received an unexpected failure from the message-switch"
+    | `Message_switch (`Communication e) ->
+      Format.fprintf fmt "There was a communication failure with message-switch: %s" (Printexc.to_string e)
 
   let error_to_msg = function
     | `Ok x -> `Ok x

--- a/core/make.mli
+++ b/core/make.mli
@@ -15,7 +15,7 @@
  *)
 
 module Connection(IO: Cohttp.S.IO) : sig
-  val rpc: (IO.ic * IO.oc) -> Protocol.In.t -> [ `Ok of string | `Error of [ `Message_switch of [ `Failed_to_read_response | `Unsuccessful_response ] ] ] IO.t
+  val rpc: (IO.ic * IO.oc) -> Protocol.In.t -> [ `Ok of string | `Error of [ `Message_switch of [ `Failed_to_read_response | `Unsuccessful_response | `Communication of exn] ] ] IO.t
 end
 
 module Server(M: S.BACKEND) : S.SERVER

--- a/core/s.mli
+++ b/core/s.mli
@@ -71,6 +71,7 @@ module type SERVER = sig
   type error = [
     | `Failed_to_read_response
     | `Unsuccessful_response
+    | `Communication of exn
   ]
 
   type 'a result = ('a, [ `Message_switch of error ]) Mresult.result
@@ -99,6 +100,7 @@ module type CLIENT = sig
     | `Unsuccessful_response
     | `Timeout
     | `Queue_deleted of string
+    | `Communication of exn
   ]
 
   type 'a result = ('a, [ `Message_switch of error ]) Mresult.result

--- a/unix/protocol_unix.ml
+++ b/unix/protocol_unix.ml
@@ -31,7 +31,7 @@ let with_lock m f =
 let thread_forever f v =
   let rec loop () =
     match f v with
-    | (_ : ('a, 'b) Message_switch_core.Mresult.result) -> assert false
+    | (_ : ('a, 'b) Mresult.result) -> assert false
     | exception e ->
       (loop[@tailcall]) ()
   in
@@ -200,9 +200,8 @@ let protect_connect path f =
     IO.disconnect conn;
     err
   | exception exn ->
-    let bt = Printexc.get_raw_backtrace () in
     IO.disconnect conn;
-    Printexc.raise_with_backtrace exn bt
+    raise exn
 
 module Client = struct
 


### PR DESCRIPTION
This is for Havana.
Master PR here: https://github.com/xapi-project/message-switch/pull/53

I have successfully created 1000 SRs with 1000 VDIs (wasn't able to actually boot any VMs due to running out of memory, but at least no more out of file descriptor errors, and no OOM during creation of the SR/VDIs).