### PR TITLE
CA-323813: do not loop infinitely when there is a communication error…

### DIFF
--- a/core/make.ml
+++ b/core/make.ml
@@ -77,6 +77,7 @@ module Client = functor(M: S.BACKEND) -> struct
     | `Unsuccessful_response
     | `Timeout
     | `Queue_deleted of string
+    | `Communication of exn
   ]
 
   type 'a result = ('a, [ `Message_switch of error]) Mresult.result
@@ -91,6 +92,8 @@ module Client = functor(M: S.BACKEND) -> struct
       Format.pp_print_string fmt "Timeout"
     | `Message_switch (`Queue_deleted name) ->
       Format.fprintf fmt "The queue %s has been deleted" name
+    | `Message_switch (`Communication e) ->
+      Format.fprintf fmt "There was a communication failure with message-switch: %s" (Printexc.to_string e)
 
   let error_to_msg = function
     | `Ok x -> `Ok x
@@ -291,6 +294,7 @@ module Server = functor(M: S.BACKEND) -> struct
   type error = [
     | `Failed_to_read_response
     | `Unsuccessful_response
+    | `Communication of exn
   ]
 
   type 'a result = ('a, [ `Message_switch of error]) Mresult.result
@@ -301,6 +305,8 @@ module Server = functor(M: S.BACKEND) -> struct
       Format.pp_print_string fmt "Failed to read response from the message-switch"
     | `Message_switch `Unsuccessful_response ->
       Format.pp_print_string fmt "Received an unexpected failure from the message-switch"
+    | `Message_switch (`Communication e) ->
+      Format.fprintf fmt "There was a communication failure with message-switch: %s" (Printexc.to_string e)
 
   let error_to_msg = function
     | `Ok x -> `Ok x

--- a/core/make.mli
+++ b/core/make.mli
@@ -15,7 +15,7 @@
  *)
 
 module Connection(IO: Cohttp.S.IO) : sig
-  val rpc: (IO.ic * IO.oc) -> Protocol.In.t -> [ `Ok of string | `Error of [ `Message_switch of [ `Failed_to_read_response | `Unsuccessful_response ] ] ] IO.t
+  val rpc: (IO.ic * IO.oc) -> Protocol.In.t -> [ `Ok of string | `Error of [ `Message_switch of [ `Failed_to_read_response | `Unsuccessful_response | `Communication of exn] ] ] IO.t
 end
 
 module Server(M: S.BACKEND) : S.SERVER

--- a/core/s.ml
+++ b/core/s.ml
@@ -71,6 +71,7 @@ module type SERVER = sig
   type error = [
     | `Failed_to_read_response
     | `Unsuccessful_response
+    | `Communication of exn
   ]
 
   type 'a result = ('a, [ `Message_switch of error ]) Mresult.result
@@ -99,6 +100,7 @@ module type CLIENT = sig
     | `Unsuccessful_response
     | `Timeout
     | `Queue_deleted of string
+    | `Communication of exn
   ]
 
   type 'a result = ('a, [ `Message_switch of error ]) Mresult.result


### PR DESCRIPTION
… with message switch

Previously in 7315f28361a307dc7458158b7c6c7c9fcdc07506 made the communication thread run forever
instead of exiting on error.
However exceptions were not caught by the IO monad used here which resulted in an infinite loop.
Catch exceptions from 'rpc' and convert them into an `Error, so that the reconnect logic handles this correctly.

In case of other exceptions throttle the loop, we still don't want to exit because that would just leave
message-switch communication broken, just keep retrying until message switch comes online.

Verified that at least squeezed is able to successfully reconnect now instead of getting stuck in an infinite loop.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>