### PR TITLE
Update opam dependencies

### DIFF
--- a/message-switch-async.opam
+++ b/message-switch-async.opam
@@ -13,11 +13,10 @@ build: [
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "ocamlfind" {build}
   "odoc" {with-doc}
-  "message-switch-core"
-  "cohttp-async" {>= "1.0.2"}
   "async" {>= "v0.9.0"}
+  "cohttp-async" {>= "1.0.2"}
+  "message-switch-core"
 ]
 synopsis: "A simple store-and-forward message switch"
 description: """

--- a/message-switch-async.opam
+++ b/message-switch-async.opam
@@ -8,7 +8,7 @@ dev-repo: "git://github.com/xapi-project/message-switch"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
-  [ "jbuilder" "build" "-p" name "-j" jobs ]
+  [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
   "ocaml"

--- a/message-switch-cli.opam
+++ b/message-switch-cli.opam
@@ -13,10 +13,10 @@ build: [
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "ocamlfind" {build}
   "odoc" {with-doc}
-  "message-switch-unix"
   "cmdliner"
+  "message-switch-unix"
+  "ppx_deriving_rpc"
 ]
 synopsis: "A simple store-and-forward message switch"
 description: """

--- a/message-switch-cli.opam
+++ b/message-switch-cli.opam
@@ -8,7 +8,7 @@ dev-repo: "git://github.com/xapi-project/message-switch"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
-  [ "jbuilder" "build" "-p" name "-j" jobs ]
+  [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
   "ocaml"

--- a/message-switch-core.opam
+++ b/message-switch-core.opam
@@ -8,7 +8,7 @@ dev-repo: "git://github.com/xapi-project/message-switch"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
-  [ "jbuilder" "build" "-p" name "-j" jobs ]
+  [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
   "ocaml"

--- a/message-switch-core.opam
+++ b/message-switch-core.opam
@@ -13,19 +13,13 @@ build: [
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "ocamlfind" {build}
   "odoc" {with-doc}
   "astring"
-  "base-unix"
   "cohttp" {>= "0.21.1"}
-  "ocaml-migrate-parsetree"
   "ppx_deriving_rpc"
   "ppx_sexp_conv"
   "rpclib"
   "sexplib"
-  "mtime" {>= "1.0.0" & < "2.0.0"}
-  "mirage-block-unix" {>= "2.4.0"}
-  "shared-block-ring" {>= "2.3.0"}
 ]
 synopsis: "A simple store-and-forward message switch"
 description: """

--- a/message-switch-lwt.opam
+++ b/message-switch-lwt.opam
@@ -13,11 +13,10 @@ build: [
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "ocamlfind" {build}
   "odoc" {with-doc}
-  "message-switch-core"
-  "lwt" {>= "3.0.0"}
   "cohttp-lwt-unix"
+  "lwt" {>= "3.0.0"}
+  "message-switch-core"
 ]
 synopsis: "A simple store-and-forward message switch"
 description: """

--- a/message-switch-lwt.opam
+++ b/message-switch-lwt.opam
@@ -8,7 +8,7 @@ dev-repo: "git://github.com/xapi-project/message-switch"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
-  [ "jbuilder" "build" "-p" name "-j" jobs ]
+  [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
   "ocaml"

--- a/message-switch-unix.opam
+++ b/message-switch-unix.opam
@@ -8,7 +8,7 @@ dev-repo: "git://github.com/xapi-project/message-switch"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
-  [ "jbuilder" "build" "-p" name "-j" jobs ]
+  [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
   "ocaml"

--- a/message-switch-unix.opam
+++ b/message-switch-unix.opam
@@ -13,9 +13,10 @@ build: [
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "ocamlfind" {build}
   "odoc" {with-doc}
+  "base-threads"
   "message-switch-core"
+  "ppx_deriving_rpc"
 ]
 synopsis: "A simple store-and-forward message switch"
 description: """

--- a/message-switch.opam
+++ b/message-switch.opam
@@ -14,15 +14,21 @@ build: [
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "ocamlfind" {build}
   "odoc" {with-doc}
-  "message-switch-lwt"
-  "message-switch-unix"
   "cmdliner"
+  "cohttp-async" {with-test}
   "cohttp-lwt-unix"
   "io-page-unix"
-  "cohttp-async" {>= "1.0.2"}
+  "lwt_log"
   "message-switch-async" {with-test}
+  "message-switch-lwt"
+  "message-switch-unix"
+  "mirage-block-unix" {>= "2.4.0"}
+  "mtime" {>= "1.0.0" & < "2.0.0"}
+  "ppx_deriving_rpc" {with-test}
+  "ppx_sexp_conv"
+  "sexplib"
+  "shared-block-ring" {>= "2.3.0"}
 ]
 synopsis: "A simple store-and-forward message switch"
 description: """

--- a/message-switch.opam
+++ b/message-switch.opam
@@ -8,8 +8,8 @@ dev-repo: "git://github.com/xapi-project/message-switch"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
-  ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml"


### PR DESCRIPTION
The dependencies for message-switch and message-switch-core were not quite right: `shared-block-ring` and `mirage-block-unix` is needed by `message-switch` itself only, and also `message-switch` only depends on `async` for tests, looks like we are linking the lwt version currently after all.

I used `dune external-lib-deps` and a python hack to create the dependency list (https://gist.github.com/edwintorok/1c13cb60ef990ba4de9a3b3dfcb9518f).

I noticed this when updating dependencies of packages as a follow-up from https://github.com/xapi-project/xs-opam/commit/f90587a239386b9387507bae01d0eae2f7d076af