### PR TITLE
CP-33380: update opam for dune 2 test compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: c
-sudo: required
-service: docker
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+os: linux
+dist: xenial
+services: docker
+install:
+  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+  - wget https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env
+  - source xs-opam-ci.env
 script: bash -ex .travis-docker.sh
 env:
   global:
     - PACKAGE=message-switch
     - PINS="message-switch-async:. message-switch-cli:. message-switch-core:.  message-switch:.  message-switch-lwt:.  message-switch-unix:."
-    - BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
-  matrix:
-    - DISTRO="debian-9-ocaml-4.07"

--- a/async/dune
+++ b/async/dune
@@ -1,11 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx))"
-  | _ -> ""
-  | exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
   (name message_switch_async)
   (public_name message-switch-async)
@@ -14,6 +6,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     cohttp-async
     message-switch-core
   )
-  %s
 )
-|} coverage_rewriter

--- a/cli/dune
+++ b/cli/dune
@@ -1,12 +1,3 @@
-(* -*- tuareg -*- *)
-
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "bisect_ppx"
-  | _ -> ""
-  | exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (executable
   (name main)
   (public_name message-cli)
@@ -16,6 +7,5 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     cmdliner
     message-switch-unix
   )
-  (preprocess (pps ppx_deriving_rpc %s))
+  (preprocess (pps ppx_deriving_rpc))
 )
-|} coverage_rewriter

--- a/core/dune
+++ b/core/dune
@@ -1,11 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "bisect_ppx"
-  | _ -> ""
-  | exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
   (name message_switch_core)
   (public_name message-switch-core)
@@ -17,6 +9,5 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     rpclib.json
     sexplib
   )
-  (preprocess (pps ppx_deriving_rpc ppx_sexp_conv %s))
+  (preprocess (pps ppx_deriving_rpc ppx_sexp_conv))
 )
-|} coverage_rewriter

--- a/core_test/async/dune
+++ b/core_test/async/dune
@@ -1,11 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx))"
-  | _ -> ""
-  | exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (executables
   (names
     client_async_main
@@ -15,6 +7,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     cohttp-async
     message-switch-async
   )
-  %s
 )
-|} coverage_rewriter

--- a/core_test/dune
+++ b/core_test/dune
@@ -1,11 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx))"
-  | _ -> ""
-  | exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (executables
   (names
     client_unix_main
@@ -14,7 +6,6 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   (libraries
     message-switch-unix
   )
-  %s
 )
 
 (alias
@@ -29,9 +20,6 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     lwt/link_test_main.exe
     ../switch/switch_main.exe
     ../cli/main.exe
-    basic-rpc-test.sh
   )
-  (package message-switch)
   (action (run ./basic-rpc-test.sh))
 )
-|} coverage_rewriter

--- a/core_test/lwt/dune
+++ b/core_test/lwt/dune
@@ -1,11 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx))"
-  | _ -> ""
-  | exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (executables
   (names
     link_test_main
@@ -16,6 +8,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     cohttp-lwt-unix
     message-switch-lwt
   )
-  %s
 )
-|} coverage_rewriter

--- a/lwt/dune
+++ b/lwt/dune
@@ -1,11 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx))"
-  | _ -> ""
-  | exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
   (name message_switch_lwt)
   (public_name message-switch-lwt)
@@ -14,6 +6,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     message-switch-core
     lwt
   )
-  %s
 )
-|} coverage_rewriter

--- a/message-switch.opam
+++ b/message-switch.opam
@@ -9,7 +9,7 @@ tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml"

--- a/switch/dune
+++ b/switch/dune
@@ -1,11 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "bisect_ppx"
-  | _ -> ""
-  | exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (executable
   (name switch_main)
   (public_name message-switch)
@@ -24,6 +16,5 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     shared-block-ring
     sexplib
   )
-  (preprocess (pps ppx_sexp_conv %s))
+  (preprocess (pps ppx_sexp_conv))
 )
-|} coverage_rewriter

--- a/unix/dune
+++ b/unix/dune
@@ -1,11 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "bisect_ppx"
-  | _ -> ""
-  | exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
   (name message_switch_unix)
   (public_name message-switch-unix)
@@ -18,6 +10,5 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     message-switch-core
     threads
   )
-  (preprocess (pps ppx_deriving_rpc %s))
+  (preprocess (pps ppx_deriving_rpc))
 )
-|} coverage_rewriter


### PR DESCRIPTION
Tests were failing because the cli rules are not available when restricting the rules to only a the `message-switch` package.

Also removed tuareg runes from dune files.