### PR TITLE
Alternative fix for XSA-354

### DIFF
--- a/switch/switch_main.ml
+++ b/switch/switch_main.ml
@@ -75,13 +75,14 @@ module Lwt_result = struct
   let ( >>= ) m f = m >>= fun x -> f (Stdlib.Result.get_ok x)
 end
 
-let make_server config =
+let make_server config trace_config =
   let open Config in
   info "Started server on %s" config.path ;
   let (_ : 'a) = logging_thread () in
   let _dump_file = "queues.sexp" in
   let _redo_log = "redo-log" in
   let redo_log_size = 1024 * 1024 in
+  let trace = Traceext.init trace_config in
   let with_file path flags mode f =
     Lwt_unix.openfile path flags mode >>= fun fd ->
     Lwt.catch
@@ -249,7 +250,7 @@ let make_server config =
         )
         >>= fun () ->
         Lwt_mutex.with_lock Switch_main_helper.m (fun () ->
-            process_request conn_id_s !queues session request
+            process_request conn_id_s !queues session request trace
             >>= fun (op_opt, response) ->
             let op = match op_opt with None -> [] | Some x -> [x] in
             perform op >>= fun () -> return response)
@@ -307,7 +308,7 @@ exception Not_a_directory of string
 
 exception Does_not_exist of string
 
-let main (Config.{pidfile; _} as config) =
+let main (Config.{pidfile; _} as config) trace_config =
   info "Starting with configuration:" ;
   info "%s" (Sexplib.Sexp.to_string (Config.sexp_of_t config)) ;
   try
@@ -333,7 +334,7 @@ let main (Config.{pidfile; _} as config) =
               Lwt_io.write oc (Printf.sprintf "%d" (Unix.getpid ()))
               >>= fun () -> Lwt_io.flush oc)
     in
-    Lwt_main.run (make_server config) ;
+    Lwt_main.run (make_server config trace_config) ;
     `Ok ()
   with
   | Not_a_directory dir ->
@@ -354,6 +355,7 @@ let cmd =
          using simple HTTP requests."
     ]
   in
-  (Term.(ret (pure main $ Config.term)), Term.info "main" ~doc ~man)
+  ( Term.(ret (pure main $ Config.term $ Traceext.term))
+  , Term.info "main" ~doc ~man )
 
 let _ = match Term.eval cmd with `Error _ -> exit 1 | _ -> exit 0

--- a/switch/traceext.ml
+++ b/switch/traceext.ml
@@ -25,7 +25,7 @@ let term =
   let config trace_entries = {trace_entries} in
   let trace_entries =
     let doc = "Maximum number of trace entries buffer (for message-cli tail)" in
-    Arg.(value & opt int 128 & info ["trace-entries"] ~doc)
+    Arg.(value & opt int 16 & info ["trace-entries"] ~doc)
   in
   Term.(pure config $ trace_entries)
 

--- a/switch/traceext.mli
+++ b/switch/traceext.mli
@@ -16,11 +16,22 @@
 
 open Message_switch_core
 
-val add : Protocol.Event.t -> unit
-(** [add t] adds a new event to the trace buffer without blocking.
+type t
+
+(** various limit settings for tracing *)
+type config
+
+val term : config Cmdliner.Term.t
+(** command-line configuration for tracing *)
+
+val init : config -> t
+(** [init config] initializes the trace extension according to [config] *)
+
+val add : t -> Protocol.Event.t -> unit
+(** [add t event] adds a new event to the trace buffer [t] without blocking.
     If the trace buffer is full then the oldest event is dropped. *)
 
-val get : int64 -> float -> (int64 * Protocol.Event.t) list Lwt.t
-(** [get from timeout] blocks until some new trace events are
-    available (whose index is > [from]) and returns a list of
+val get : t -> int64 -> float -> (int64 * Protocol.Event.t) list Lwt.t
+(** [get t from timeout] blocks until some new trace events are
+    available in [t] (whose index is > [from]) and returns a list of
     [index, Event.t] *)


### PR DESCRIPTION
XSA-354 occurs because message-switch's trace buffer holds on to last 128 messages.
These can be fairly large when there are no xenopsd quotas, and JSON also adds a further 6x increase in size (due to \u encoding).

Make the size configurable and default it to 16, and store messages in parsed format, not as JSON, reducing worst case memory usage 96x.

Also truncate very long strings inside the JSON dictionary (default: when longer than 256: truncate and add a UTF-8 ellipsis).

Now even without xenopsd quota enforcement we avoid OOM (though retaining some form of quota in xenopsd is useful, see: https://github.com/xapi-project/xenopsd/pull/739)