### PR TITLE
maintenance: remove unused types

### DIFF
--- a/switch/traceext.ml
+++ b/switch/traceext.ml
@@ -16,8 +16,6 @@
 
 open Lwt
 
-type message_id = string * int64
-
 module CompactMessage : sig
   type t
 
@@ -30,8 +28,6 @@ end = struct
   open Message_switch_core.Protocol
 
   let truncate_at = ref 0
-
-  type kind = Message.kind
 
   type payload = Raw of string | Rpc of Rpc.t
 


### PR DESCRIPTION
This is causing tests to fail on xs-opam because `--profile=release` is not used to build the tests (and `-p name` cannot be used as it tests many packages)

https://github.com/xapi-project/xs-opam/runs/1876701006?check_suite_focus=true