### PR TITLE
CP-34942: Removed unused bindings when updating mirage

### DIFF
--- a/switch/clock.ml
+++ b/switch/clock.ml
@@ -16,12 +16,4 @@
 
 include Mtime_clock
 
-type +'a io = 'a Lwt.t
-
-type t = unit
-
-let disconnect () = Lwt.return_unit
-
-let connect () = Lwt.return_unit
-
 let ns () = Mtime.Span.to_uint64_ns (Mtime_clock.elapsed ())

--- a/switch/time.ml
+++ b/switch/time.ml
@@ -14,7 +14,5 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type +'a io = 'a Lwt.t
-
 let sleep_ns nanoseconds =
   Lwt_unix.sleep (Int64.to_float nanoseconds *. Mtime.ns_to_s)


### PR DESCRIPTION
This change is tested in https://github.com/xapi-project/xs-opam/pull/559. The PR can be merged once the ci in the xs-opam repo passes.