### PR TITLE
ci: remove scheduled run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,6 @@ name: Build and test
 on:
   push:
   pull_request:
-  schedule:
-    # run daily, this refreshes the cache
-    - cron: '45 1 * * *'
 
 jobs:
   ocaml-test:


### PR DESCRIPTION
Having a scheduled run inactive during 60 days caused the workflows to
be deactivated for pushes on the main branch and on PRs. Remove it since
it was not being useful because of the low activity.

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>