### PR TITLE
CP-38064: update code for jst 0.13.0 compatibility

### DIFF
--- a/async/protocol_async.ml
+++ b/async/protocol_async.ml
@@ -55,8 +55,9 @@ module M = struct
       Monitor.try_with ~extract_exn:true connect >>= function
       | Error
           (Unix.Unix_error
-            ((Unix.ECONNREFUSED | Unix.ECONNABORTED | Unix.ENOENT), _, _)) ->
-          let delay = min maximum_delay delay in
+            (Core.(Unix.ECONNREFUSED | Unix.ECONNABORTED | Unix.ENOENT), _, _))
+        ->
+          let delay = Float.min maximum_delay delay in
           Clock.after (Time.Span.of_sec delay) >>= fun () ->
           retry (delay +. delay)
       | Error e ->
@@ -80,7 +81,7 @@ module M = struct
 
     let with_lock t f =
       let rec wait state =
-        if t.m = state then
+        if Bool.(t.m = state) then
           return ()
         else
           Condition.wait t.c >>= fun () -> wait state

--- a/configure
+++ b/configure
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-D=$(mktemp -d /tmp/configure.XXXXX)
+D=$(mktemp -d ${TMPDIR:-/tmp}/configure.XXXXX)
 function cleanup {
   cd /
   rm -rf $D

--- a/switch/traceext.ml
+++ b/switch/traceext.ml
@@ -16,8 +16,6 @@
 
 open Lwt
 
-type message_id = string * int64
-
 module CompactMessage : sig
   type t
 
@@ -30,8 +28,6 @@ end = struct
   open Message_switch_core.Protocol
 
   let truncate_at = ref 0
-
-  type kind = Message.kind
 
   type payload = Raw of string | Rpc of Rpc.t
 

--- a/switch/traceext.ml
+++ b/switch/traceext.ml
@@ -53,6 +53,8 @@ end = struct
         orig
     | Rpc.Enum l ->
         Rpc.Enum (List.rev_map truncate_rpc l |> List.rev)
+    | Rpc.Base64 s ->
+        Rpc.Base64 (truncate s)
     | Rpc.Dict d ->
         Rpc.Dict (List.rev_map truncate_rpc_kv d |> List.rev)
     | Rpc.String s ->


### PR DESCRIPTION
This compatibility is needed to support updating ppxlib for Yangtze.

Stockholm now uses branch 1.23.1-lcm

The code includes a piece for truncanting base64 entries that was missing from the original backport because of the difference in rpclib version.

The successful compilation can be seen in https://github.com/xapi-project/xs-opam/runs/3399090781