### PR TITLE
xapi-storage-script: enable building from tarball

### DIFF
--- a/xapi-storage-script/dune
+++ b/xapi-storage-script/dune
@@ -1,7 +1,7 @@
 (rule
   (targets VERSION)
   (mode fallback)
-  (action (with-stdout-to %{targets} (bash "git describe --always --dirty")))
+  (action (with-stdout-to %{targets} (bash "git describe --always --dirty || echo 0.0.0")))
 )
 
 (rule


### PR DESCRIPTION
The merge to this repository forced git to be present. Allow a fallback
mechanism when the package is being built from a tarball.

This is a temporary solution, the package is being merged into xen-api.git and _that_ has a robust way to access the version number.

This fixes https://github.com/xapi-project/xs-opam/pull/587